### PR TITLE
Fix random number and remove `entry`

### DIFF
--- a/src/id_rand.f
+++ b/src/id_rand.f
@@ -31,7 +31,7 @@ c
 c
 c
 c
-        subroutine id_frand(n,r)
+        subroutine id_frand_help(n,r,iflag,t)
 c
 c       generates n pseudorandom numbers drawn uniformly from [0,1],
 c       via a very efficient lagged Fibonnaci method.
@@ -40,6 +40,11 @@ c       n be at least 55.
 c
 c       input:
 c       n -- number of pseudorandom numbers to generate
+c       iflag -- iflag to set seeds or generate random numbers
+c                1 set seeds to t
+c                2 set seeds to original s0
+c                else generate random numbers
+c       t -- seeds to set if iflag == 1
 c
 c       output:
 c       r -- array of pseudorandom numbers
@@ -52,7 +57,7 @@ c            3rd edition, Cambridge University Press, 2007,
 c            Section 7.1.5.
 c
         implicit none
-        integer n,k
+        integer n,k,iflag
         real*8 r(n),s(55),t(55),s0(55),x
         save
 c
@@ -117,6 +122,33 @@ c
      8  0.9920272858340107d0/
 c
 c
+c       initializes the seed values in s
+c       (any appropriately random numbers will do).
+c
+c       input:
+c       t -- values to copy into s
+c
+        if(iflag.eq.1) then
+          do k = 1,55
+            s(k) = t(k)
+          enddo ! k
+          return
+        endif
+c
+c
+c
+c
+c       initializes the seed values in s to their original values.
+c
+        if(iflag.eq.2) then
+          do k = 1,55
+            s(k) = s0(k)
+          enddo ! k
+          return
+        endif
+c
+
+c
         do k = 1,24
 c
           x = s(k+31)-s(k)
@@ -149,41 +181,78 @@ c
         enddo ! k
 c
 c
-        return
 c
 c
-c
-        entry id_frandi(t)
-c
-c       initializes the seed values in s
-c       (any appropriately random numbers will do).
-c
-c       input:
-c       t -- values to copy into s
-c
-        do k = 1,55
-          s(k) = t(k)
-        enddo ! k
-c
-        return
-c
-c
-c
-        entry id_frando()
-c
-c       initializes the seed values in s to their original values.
-c
-        do k = 1,55
-          s(k) = s0(k)
-        enddo ! k
 c
         return
         end
 c
 c
 c
+        subroutine id_frandi(t)
+        implicit none
+        integer n,iflag
+        real*8 dummy(1),t(55)
+
+        n=1
+        iflag = 1
+        call id_frand_help(n,dummy,iflag,t)
+        
+        end
 c
-        subroutine id_srand(n,r)
+c
+c
+        subroutine id_frando()
+        implicit none
+        integer n,iflag
+        real*8 dummy1(1), dummy2(55)
+
+        n=1
+        iflag = 2
+        call id_frand_help(n,dummy1,iflag,dummy2)
+        
+        end
+c
+c
+c
+c
+c
+c
+c
+        subroutine id_frand(n,r)
+c
+c       generates n pseudorandom numbers drawn uniformly from [0,1],
+c       via a very efficient lagged Fibonnaci method.
+c       Unlike routine id_srand, the present routine requires that
+c       n be at least 55.
+c
+c       input:
+c       n -- number of pseudorandom numbers to generate
+c
+c       output:
+c       r -- array of pseudorandom numbers
+c
+c       _N.B._: n must be at least 55.
+c
+c       reference:
+c       Press, Teukolsky, Vetterling, Flannery, "Numerical Recipes,"
+c            3rd edition, Cambridge University Press, 2007,
+c            Section 7.1.5.
+c
+        implicit none
+        integer n,iflag
+        real*8 r(n), dummy(55)
+        
+        iflag = 0
+        call id_frand_help(n,r,iflag,dummy)
+        
+        return
+        end
+c
+c
+c
+c
+        subroutine id_srand_help(n,r,iflag,t)
 c
 c       generates n pseudorandom numbers drawn uniformly from [0,1],
 c       via a very efficient lagged Fibonnaci method.
@@ -192,6 +261,11 @@ c       that n be at least 55.
 c
 c       input:
 c       n -- number of pseudorandom numbers to generate
+c       iflag -- iflag to set seeds or generate random numbers
+c                1 set seeds to t
+c                2 set seeds to original s0
+c                else generate random numbers
+c       t -- seeds to set if iflag == 1
 c
 c       output:
 c       r -- array of pseudorandom numbers
@@ -202,7 +276,7 @@ c            3rd edition, Cambridge University Press, 2007,
 c            Section 7.1.5.
 c
         implicit none
-        integer n,k,l,m
+        integer n,k,l,m,iflag
         real*8 s(55),r(n),s0(55),t(55),x
         save
 c
@@ -269,6 +343,42 @@ c
      8  0.8539399636754000d0/
 c
 c
+c
+c
+c       initializes the seed values in s
+c       (any appropriately random numbers will do).
+c
+c       input:
+c       t -- values to copy into s
+c
+        if(iflag.eq.1) then
+          do k = 1,55
+            s(k) = t(k)
+          enddo ! k
+c
+          l = 55
+          m = 24
+          return
+        endif
+c
+c
+c
+c
+c       initializes the seed values in s to their original values.
+c
+        if(iflag.eq.2) then
+          do k = 1,55
+            s(k) = s0(k)
+          enddo ! k
+c
+          l = 55
+          m = 24
+          return
+        endif
+c
+
+c
+c
         do k = 1,n
 c
 c         Run one step of the recurrence.
@@ -292,42 +402,66 @@ c
 c
 c
         return
+        end
 c
 c
 c
-        entry id_srandi(t)
 c
-c       initializes the seed values in s
-c       (any appropriately random numbers will do).
+        subroutine id_srand(n,r)
+c
+c       generates n pseudorandom numbers drawn uniformly from [0,1],
+c       via a very efficient lagged Fibonnaci method.
+c       Unlike routine id_frand, the present routine does not requires
+c       that n be at least 55.
 c
 c       input:
-c       t -- values to copy into s
+c       n -- number of pseudorandom numbers to generate
 c
-        do k = 1,55
-          s(k) = t(k)
-        enddo ! k
+c       output:
+c       r -- array of pseudorandom numbers
 c
-        l = 55
-        m = 24
+c       reference:
+c       Press, Teukolsky, Vetterling, Flannery, "Numerical Recipes,"
+c            3rd edition, Cambridge University Press, 2007,
+c            Section 7.1.5.
 c
-        return
-c
-c
-c
-        entry id_srando()
-c
-c       initializes the seed values in s to their original values.
-c
-        do k = 1,55
-          s(k) = s0(k)
-        enddo ! k
-c
-        l = 55
-        m = 24
-c
+        implicit none
+        integer n,iflag
+        real*8 r(n),dummy(55)
+
+        
+        iflag = 0
+        call id_srand_help(n,r,iflag,dummy)
+
         return
         end
 c
+c
+c
+c
+        subroutine id_srandi(t)
+        implicit none
+        integer n,iflag
+        real*8 dummy(1),t(55)
+
+        n=1
+        iflag = 1
+        call id_srand_help(n,dummy,iflag,t)
+        
+        end
+c
+c
+c
+        subroutine id_srando()
+        implicit none
+        integer n,iflag
+        real*8 dummy1(1), dummy2(55)
+
+        n=1
+        iflag = 2
+        call id_srand_help(n,dummy1,iflag,dummy2)
+        
+        end
 c
 c
 c

--- a/src/iddp_rid.f
+++ b/src/iddp_rid.f
@@ -252,6 +252,9 @@ c
 c         Apply the transpose of a to a random vector.
 c
           call id_srand(m,x)
+          do k  = 1,m
+            x(k) = 2*x(k) - 1.0d0
+          enddo
           call matvect(m,x,n,ra(1,1,krank+1),p1,p2,p3,p4)
 c
           do k = 1,n

--- a/src/idz_snorm.f
+++ b/src/idz_snorm.f
@@ -83,8 +83,9 @@ c
         implicit none
         integer m,n,its,it,n2,k
         real*8 snorm,enorm
-        complex*16 p1a,p2a,p3a,p4a,p1,p2,p3,p4,u(m),v(n)
+        complex*16 p1a,p2a,p3a,p4a,p1,p2,p3,p4,u(m),v(n),one
         external matveca,matvec
+        data one/(1.0d0,1.0d0)/
 c
 c
 c       Fill the real and imaginary parts of each entry
@@ -95,7 +96,7 @@ c
         call id_srand(n2,v)
 c
         do k = 1,n
-          v(k) = 2*v(k)-1
+          v(k) = 2*v(k)-one
         enddo ! k
 c
 c
@@ -337,8 +338,9 @@ c
         real*8 snorm,enorm
         complex*16 p1a,p2a,p3a,p4a,p1a2,p2a2,p3a2,p4a2,
      1             p1,p2,p3,p4,p12,p22,p32,p42,u(m),u1(m),u2(m),
-     2             v(n),v1(n),v2(n)
+     2             v(n),v1(n),v2(n),one
         external matveca,matvec,matveca2,matvec2
+        data one/(1.0d0,1.0d0)/
 c
 c
 c       Fill the real and imaginary parts of each entry
@@ -349,7 +351,7 @@ c
         call id_srand(n2,v)
 c
         do k = 1,n
-          v(k) = 2*v(k)-1
+          v(k) = 2*v(k)-one
         enddo ! k
 c
 c

--- a/src/idzp_rid.f
+++ b/src/idzp_rid.f
@@ -231,7 +231,9 @@ c
         integer m,n,krank,ifrescal,k,lra,ier,m2
         real*8 eps,enorm
         complex*16 x(m),ra(n,2,*),p1,p2,p3,p4,scal(n+1),y(n),residual
+        complex*16 one
         external matveca
+        data one/(1.0d0,1.0d0)/
 c
 c
         ier = 0
@@ -256,6 +258,9 @@ c         Apply the adjoint of a to a random vector.
 c
           m2 = m*2
           call id_srand(m2,x)
+          do k=1,m
+            x(k) = 2*x(k) - one
+          enddo
           call matveca(m,x,n,ra(1,1,krank+1),p1,p2,p3,p4)
 c
           do k = 1,n

--- a/test/iddp_rid_test.f
+++ b/test/iddp_rid_test.f
@@ -25,7 +25,9 @@ c
         read *,n
         call prinf('n = *',n,1)
 c
-        krank = 5
+c        krank = 5
+        print *,'Enter k:'
+        read *,krank
         call prinf('krank = *',krank,1)
 c
 c
@@ -36,7 +38,11 @@ c
 c
 c       ID a via a randomized algorithm.
 c
-        eps = .1d-12
+c        eps = .1d-12
+        print *,'Enter eps:'
+        read *,eps
+        print *, "eps: ", eps
+
         lproj = len
 c
         call iddp_rid(lproj,eps,m,n,matvect,a,p2,p3,p4,
@@ -84,22 +90,52 @@ c       a -- filled matrix
 c
         implicit none
         integer krank,j,k,l,m,n
+        integer krank1,krank2,krank3
         real*8 r1,pi,a(m,n),sum
+        real*8 val1,val2,val3
+
+        krank1 = krank/3
+        krank2 = krank1*2
+        krank3 = krank
 c
         r1 = 1
         pi = 4*atan(r1)
 c
+        val1 = 3
 c
         do k = 1,n
           do j = 1,m
 c
             sum = 0
 c
-            do l = 1,krank
+
+            do l = 1,krank1
               sum = sum+cos(pi*(j-r1/2)*(l-r1/2)/m)*sqrt(r1*2/m)
      1                 *cos(pi*(k-r1/2)*(l-r1/2)/n)*sqrt(r1*2/n)
-     2                 *exp(log(1d-10)*(l-1)/(krank-1))
+     2                 *exp(log(1d-10)*(l-1)/(krank-1))*val1
             enddo ! l
+
+            val2 = exp(log(1d-10)*(krank1-1)/(krank-1))*val1
+
+            do l = krank1+1,krank2
+              sum = sum+cos(pi*(j-r1/2)*(l-r1/2)/m)*sqrt(r1*2/m)
+     1                 *cos(pi*(k-r1/2)*(l-r1/2)/n)*sqrt(r1*2/n)
+     2                 *(krank+krank1+1.0-l)/krank*val2
+            enddo ! l
+
+            val3 = (krank+krank1+1.0-krank2)/krank*val2
+
+            do l = krank2+1,krank3
+              sum = sum+cos(pi*(j-r1/2)*(l-r1/2)/m)*sqrt(r1*2/m)
+     1                 *cos(pi*(k-r1/2)*(l-r1/2)/n)*sqrt(r1*2/n)
+     2                 *exp(log(1d-10)*(l-1)/(krank-1))*val3
+            enddo ! l
+
+cc            do l = 1,krank
+cc              sum = sum+cos(pi*(j-r1/2)*(l-r1/2)/m)*sqrt(r1*2/m)
+cc     1                 *cos(pi*(k-r1/2)*(l-r1/2)/n)*sqrt(r1*2/n)
+cc     2                 *exp(log(1d-10)*(l-1)/(krank-1))
+cc            enddo ! l
 c
             a(j,k) = sum
 c


### PR DESCRIPTION
1. All random numbers used for rank revealing are centered at 0.
2. remove deprecated `entry` keyword.